### PR TITLE
getCapabilities() changed in selenium-webdriver

### DIFF
--- a/visualreview-protractor.js
+++ b/visualreview-protractor.js
@@ -33,9 +33,9 @@ module.exports = function (options) {
   _metaDataFn = options.metaDataFn || function () { return {}; };
   _propertiesFn = options.propertiesFn || function (capabilities) {
     return {
-      'os': capabilities.caps_.platform,
-      'browser': capabilities.caps_.browserName,
-      'version': capabilities.caps_.version
+      'os': capabilities.get('platform'),
+      'browser': capabilities.get('browserName'),
+      'version': capabilities.get('version')
     }
   };
 


### PR DESCRIPTION
When I tried to use VisualReview-protractor after updating to a more-recent version of protractor I get an error because how capabilities are accessed has been changed in the underlying selenium-webdriver library. I made a really small tweak that I think should update your module to work with newer versions.
