### PR TITLE
Add options to use https and disable ssl certificate check

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Then configure visualreview-protractor in your protractor configuration file. He
 const VisualReview = require('visualreview-protractor');
 var vr = new VisualReview({
   hostname: 'localhost',
-  port: 7000
+  port: 7000,
+  scheme: 'https', //(optional: http|https, http is used if not specified)
+  strictSSL: true //(optional: true|false, disable ssl certificate check, true if not specified)
 });
 
 exports.config = {

--- a/lib/vr-client.js
+++ b/lib/vr-client.js
@@ -18,11 +18,13 @@ const util = require('util');
 const q = require('q');
 const request = require('request');
 
-var _hostname, _port;
+var _hostname, _port, _scheme, _strictSSL;
 
-module.exports = function (hostname, port) {
+module.exports = function (hostname, port, scheme, strictSSL) {
 	_hostname = hostname;
 	_port = port;
+	_scheme = scheme||'http';
+	_strictSSL = strictSSL === false ? false : true;
 
 	return {
 		createRun: createRun,
@@ -101,8 +103,11 @@ function _callServer (method, path, jsonBody, multiPartFormOptions) {
 
 	var requestOptions = {
 		method: method.toUpperCase(),
-		uri: 'http://' + _hostname + ':' + _port + '/api/' + path
+		uri: _scheme+'://' + _hostname + ':' + _port + '/api/' + path,
+		strictSSL: _strictSSL
 	};
+
+	console.log('DEBUG: '+requestOptions.strictSSL);
 
 	// for JSON body request
 	if (jsonBody) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "visualreview-protractor",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Provides an API to send screenshots to VisualReview from Protractor tests.",
   "homepage": "https://github.com/xebia/VisualReview-protractor",
   "author": "Xebia",

--- a/visualreview-protractor.js
+++ b/visualreview-protractor.js
@@ -23,20 +23,22 @@ const VrClient = require('./lib/vr-client.js');
 const RUN_PID_FILE = '.visualreview-runid.pid';
 const LOG_PREFIX = 'VisualReview-protractor: ';
 
-var _hostname, _port, _client, _metaDataFn, _propertiesFn, _compareSettingsFn;
+var _hostname, _port, _client, _metaDataFn, _propertiesFn, _compareSettingsFn, _scheme, _strictSSL;
 
 module.exports = function (options) {
   _hostname = options.hostname || 'localhost';
   _port = options.port || 7000;
+  _scheme = options.scheme || 'http';
+  _strictSSL = options.strictSSL === false ? false : true;
   _disabled = options.disabled || false;
-  _client = new VrClient(_hostname, _port);
+  _client = new VrClient(_hostname, _port, _scheme, _strictSSL);
   _metaDataFn = options.metaDataFn || function () { return {}; };
   _propertiesFn = options.propertiesFn || function (capabilities) {
     return {
       'os': capabilities.get('platform'),
       'browser': capabilities.get('browserName'),
       'version': capabilities.get('version')
-    }
+    };
   };
   _compareSettingsFn = options.compareSettings || null;
 
@@ -116,7 +118,7 @@ function cleanup (exitCode) {
 
   _readRunIdFile().then(function (run) {
     _logMessage('test finished. Your results can be viewed at: ' +
-      'http://' + _hostname + ':' + _port + '/#/' + run.project_id + '/' + run.suite_id + '/' + run.run_id + '/rp');
+      _scheme+'://' + _hostname + ':' + _port + '/#/' + run.project_id + '/' + run.suite_id + '/' + run.run_id + '/rp');
     fs.unlink(RUN_PID_FILE, function (err) {
       if (err) {
         defer.reject(err);


### PR DESCRIPTION
Add 2 new options
- https:
To use the vr client with a vr server behind a ssl proxy

- disable ssl certificate check:
To use the vr client with self signed or private CA signed certificates

**Example**
```
var vr = new VisualReview({
  hostname: 'visualreview.mydomain.net',
  port: 443,
  scheme: 'https',
  strictSSL: false
});
```